### PR TITLE
Add target root path support to dotenv script

### DIFF
--- a/dotenv
+++ b/dotenv
@@ -2,6 +2,9 @@
 
 export ENV_ROOT=$(cd `dirname ${BASH_SOURCE[0]}` && pwd)
 
+# Default target root to HOME, can be overridden with --target-root
+export TARGET_ROOT="$HOME"
+
 source ${ENV_ROOT}/inc/base.sh
 source ${ENV_ROOT}/inc/install.sh
 source ${ENV_ROOT}/inc/config.sh
@@ -14,7 +17,23 @@ fi
 export SHELL_NAME=`basename ${SHELL_PATH:-bash}`
 
 function print_usage() {
-    echo "Usages: $0 patch|install|config|all"
+    echo "Usages: $0 [OPTIONS] [COMMAND]"
+    echo ""
+    echo "OPTIONS:"
+    echo "  --target-root <path>  Specify target directory for rc files (default: \$HOME)"
+    echo ""
+    echo "COMMANDS:"
+    echo "  patch        Patch rc files (.bashrc, .vimrc, etc.)"
+    echo "  install      Install vim-plug, tmux tpm, fzf"
+    echo "  config       Configure git and vim"
+    echo "  config-git   Configure git only"
+    echo "  config-vim   Configure vim only"
+    echo "  all          Run all commands (default)"
+    echo ""
+    echo "EXAMPLES:"
+    echo "  $0                              # Run all commands with default target (~)"
+    echo "  $0 --target-root /opt/myenv     # Run all commands targeting /opt/myenv"
+    echo "  $0 --target-root /opt/myenv patch  # Only patch rc files in /opt/myenv"
 }
 
 function patch() {
@@ -52,13 +71,46 @@ function default_action() {
     config
 }
 
-if [ ${#@} -eq 0 ]; then
+# Parse arguments
+COMMANDS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target-root)
+            if [ -z "$2" ]; then
+                echo "Error: --target-root requires a path argument"
+                print_usage
+                exit 1
+            fi
+            export TARGET_ROOT="$2"
+            # Create target directory if it doesn't exist
+            mkdir -p "$TARGET_ROOT"
+            shift 2
+            ;;
+        -h|--help|--usage|-H)
+            print_usage
+            exit 0
+            ;;
+        patch|install|config|config-git|config-vim|all)
+            COMMANDS+=("$1")
+            shift
+            ;;
+        *)
+            echo "Unknown option or command: $1"
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+# If no commands specified, run default action
+if [ ${#COMMANDS[@]} -eq 0 ]; then
     default_action
     exit 0
 fi
 
-for var in "$@"; do
-    case "$var" in
+# Execute commands
+for cmd in "${COMMANDS[@]}"; do
+    case "$cmd" in
         patch)
             patch;;
         install)
@@ -69,10 +121,7 @@ for var in "$@"; do
             config_git;;
         config-vim)
             config_vim;;
-        -h|--help|--usage|-H)
-            print_usage $0;;
-        *)
-            default_action
-            ;;
+        all)
+            default_action;;
     esac
 done

--- a/inc/config.sh
+++ b/inc/config.sh
@@ -1,7 +1,8 @@
 # Config
 
 function config_vim_plug() {
-    vim -E -s -u "~/.vimrc" +PlugInstall +qall
+    local target_root="${TARGET_ROOT:-$HOME}"
+    vim -E -s -u "$target_root/.vimrc" +PlugInstall +qall
 }
 
 function config_git_vim_diff() {

--- a/inc/patch.sh
+++ b/inc/patch.sh
@@ -14,15 +14,16 @@ function get_line_number() {
 }
 
 function get_shell_rc_path() {
+    local target_root="${TARGET_ROOT:-$HOME}"
     case "$1" in
         *csh)
-            echo "$HOME/.cshrc"
+            echo "$target_root/.cshrc"
             ;;
         *bash)
-            echo "$HOME/.bashrc"
+            echo "$target_root/.bashrc"
             ;;
         *zsh)
-            echo "$HOME/.zshrc"
+            echo "$target_root/.zshrc"
             ;;
         *)
             echo "Unsupported shell (only supports csh, bash and zsh)"
@@ -62,15 +63,19 @@ function patch_shell_rc() {
         return
     fi
     local temp=`mktemp`
-    cat $rc > $temp
+    # Create rc file if it doesn't exist
+    if [ -f "$rc" ]; then
+        cat $rc > $temp
+        mv $rc ${rc}-`date +%F-%H-%M-%S`.bak
+    fi
     get_patched_rc $shell_name >> $temp
-    mv $rc ${rc}-`date +%F-%H-%M-%S`.bak
     mv $temp $rc
     echo "$rc patched"
 }
 
 function patch_tmux_rc() {
-    local tmuxrc=$HOME/.tmux.conf
+    local target_root="${TARGET_ROOT:-$HOME}"
+    local tmuxrc=$target_root/.tmux.conf
     if [ "`grep \"$ENV_BLOCK_HEAD\" $tmuxrc 2> /dev/null`" = "" ]; then
         echo "Patching $tmuxrc ... "
         cat "${ENV_ROOT}/seeds/tmux.conf" >> $tmuxrc
@@ -81,12 +86,14 @@ function patch_tmux_rc() {
 }
 
 function patch_vim_rc() {
-    local vimrc=$HOME/.vimrc
-    local local_vimrc=$HOME/.vimrc.plug
+    local target_root="${TARGET_ROOT:-$HOME}"
+    local vimrc=$target_root/.vimrc
+    local local_vimrc=$target_root/.vimrc.plug
     if [ "`grep \"$ENV_BLOCK_HEAD\" $vimrc 2> /dev/null`" = "" ]; then
         echo "Patching $vimrc ..."
         echo -e "\n\" $ENV_BLOCK_HEAD" >> $vimrc
         echo "\" =Begin=" >> $vimrc
+        echo "let g:target_root = '$target_root'" >> $vimrc
         echo "source $ENV_ROOT/vim/plug.vimrc" >> $vimrc
         echo "\" Update local Plug at $local_vimrc" >> $vimrc
         echo "source $ENV_ROOT/vim/helpers.vimrc" >> $vimrc
@@ -100,8 +107,9 @@ function patch_vim_rc() {
 }
 
 function patch_nvim_rc() {
-    local nvimrc=$HOME/.config/nvim/init.vim
-    local local_nvimrc=$HOME/.config/nvim/extra-plug.vim
+    local target_root="${TARGET_ROOT:-$HOME}"
+    local nvimrc=$target_root/.config/nvim/init.vim
+    local local_nvimrc=$target_root/.config/nvim/extra-plug.vim
     mkdir -p `dirname $nvimrc`;
     mkdir -p `dirname $local_nvimrc`;
 	touch $local_nvimrc
@@ -122,7 +130,8 @@ function patch_nvim_rc() {
 }
 
 function patch_screen_rc() {
-    local screenrc=$HOME/.screenrc
+    local target_root="${TARGET_ROOT:-$HOME}"
+    local screenrc=$target_root/.screenrc
     if [ "`grep \"$ENV_BLOCK_HEAD\" $screenrc 2> /dev/null`" = "" ]; then
         echo "Patching $screenrc ... "
         cat "${ENV_ROOT}/seeds/screenrc" >> $screenrc
@@ -132,7 +141,8 @@ function patch_screen_rc() {
 }
 
 function patch_hammerspoon() {
-    local hammerspoon_init=$HOME/.hammerspoon/init.lua
+    local target_root="${TARGET_ROOT:-$HOME}"
+    local hammerspoon_init=$target_root/.hammerspoon/init.lua
     local seed_file="${ENV_ROOT}/seeds/hammerspoon/init.lua"
 
     # Create directory if it doesn't exist
@@ -151,7 +161,8 @@ function patch_hammerspoon() {
 }
 
 function patch_karabiner() {
-    local karabiner_config=$HOME/.config/karabiner/karabiner.json
+    local target_root="${TARGET_ROOT:-$HOME}"
+    local karabiner_config=$target_root/.config/karabiner/karabiner.json
     local seed_file="${ENV_ROOT}/seeds/karabiner/karabiner.json"
 
     # Create directory if it doesn't exist

--- a/vim/plug.vimrc
+++ b/vim/plug.vimrc
@@ -1,11 +1,16 @@
-call plug#begin('~/.vim/plugged')
+" Use target_root if set, otherwise default to $HOME
+if !exists('g:target_root')
+    let g:target_root = $HOME
+endif
+
+call plug#begin(g:target_root . '/.vim/plugged')
 
 if has("nvim")
 Plug 'neoclide/coc.nvim', {'branch': 'release'}
 endif
 
 if v:version < 800
-Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
+Plug 'junegunn/fzf', { 'dir': g:target_root . '/.fzf', 'do': './install --all' }
 else
 Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
 endif
@@ -57,9 +62,9 @@ Plug 'NLKNguyen/papercolor-theme'
 "    let g:closetag_xhtml_filetypes = 'xhtml,jsx'
 "    let g:closetag_filenames = "*.html,*.xhtml,*.phtml,*.php,*.jsx"
 
-if filereadable($HOME."/.vimrc.plug")
+if filereadable(g:target_root . "/.vimrc.plug")
     " Put your local plug here
-    source $HOME/.vimrc.plug
+    execute 'source ' . g:target_root . '/.vimrc.plug'
 endif
 
 " Initialize plugin system


### PR DESCRIPTION
Add support for --target-root <path> option to allow patching rc files in a specified directory instead of always using $HOME. This makes the dotenv script more flexible and allows it to work correctly regardless of where the repository folder is placed.

Changes:
- Add --target-root argument parsing to main dotenv script
- Update all patch functions to use TARGET_ROOT instead of hardcoded $HOME
- Modify vim configuration to use g:target_root variable for plugin paths
- Fix patch_shell_rc to handle non-existent rc files gracefully
- Improve help message with usage examples
- Ensure backward compatibility (defaults to $HOME when not specified)

The repository can now be placed anywhere and running ./dotenv will work correctly. Users can also specify a custom target root for all rc files.