### PR TITLE
feat: add macOS shortcuts section and timestamped backup notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ powershell -File $HOME\.env\dotenv.ps1   # patches your PowerShell profile with 
 - **Vim / Neovim**: Sources configs from `vim/` plus local override files (`~/.vimrc.plug`, `~/.config/nvim/extra-plug.vim`) and wires in `vim-plug`.
 - **Git defaults**: Sets `vimdiff` as the difftool, `vim` as core editor, and a long-lived credential cache.
 - **Tools**: Installs `vim-plug`, `tmux-tpm`, and `fzf` automatically. Helpers for `nvm` and macOS text keybindings are available in `inc/install.sh`.
-- **macOS extras**: Seeds for Hammerspoon and Karabiner are copied with backups if files already exist.
+- **macOS extras**: Seeds for Hammerspoon and Karabiner are copied with timestamped backups (`.bak-YYYY-MM-DD-HH-MM-SS`) if files already exist.
 - **Windows extras**: PowerShell profile patcher imports git aliases and a prompt from `inc/`.
 
 ## Usage
@@ -43,6 +43,49 @@ powershell -File $HOME\.env\dotenv.ps1   # patches your PowerShell profile with 
   Run targeted steps instead of the full flow.
 - `ENV_ROOT` points to the clone; templates live in `seeds/`, and functions live in `inc/`.
 - Shell rc patching is idempotent; rerunning will skip already-patched files. For shell rc files, a `*.bak-<timestamp>` backup is created before changes.
+
+## macOS Keyboard Shortcuts
+The included Karabiner and Hammerspoon configurations provide powerful keyboard shortcuts for window management and productivity.
+
+| Category | Shortcut | Action |
+|----------|----------|--------|
+| **Karabiner (System-level Key Remapping)** |||
+| **Remapping** | **Cmd + Shift** (tap) | Switch input source (acts as Ctrl + Space when tapped alone) |
+| **Remapping** | **fn + Ctrl + 1/2/3** | Remapped to Ctrl + Shift + Option + 1/2/3 (triggers Hammerspoon 2/3 width layouts) |
+| **Remapping** | **Page Down/Up** | Remapped to fn + Down/Up |
+| **Remapping** | **Home/End** | Remapped to Cmd + Left/Right |
+| **Hammerspoon (Window Management & Utilities)** |||
+| **Window: 1/3** | **Ctrl + Option + 1** | Position window at left 1/3 |
+| **Window: 1/3** | **Ctrl + Option + 2** | Position window at middle 1/3 |
+| **Window: 1/3** | **Ctrl + Option + 3** | Position window at right 1/3 |
+| **Window: 2/3** | **Ctrl + Shift + Option + 1** | Position window at left 2/3 |
+| **Window: 2/3** | **Ctrl + Shift + Option + 2** | Position window at middle 2/3 |
+| **Window: 2/3** | **Ctrl + Shift + Option + 3** | Position window at right 2/3 |
+| **Window: Half** | **Ctrl + Option + Left** | Position window at left half |
+| **Window: Half** | **Ctrl + Option + Right** | Position window at right half |
+| **Window: Center** | **Ctrl + Option + C** | Center window (70% size) |
+| **Multi-Display** | **Ctrl + Option + Cmd + N** | Move window to next display |
+| **Multi-Display** | **Ctrl + Option + Cmd + M** | Move window to next display and maximize |
+| **Productivity** | **Ctrl + Option + D** | Open macOS Dictionary and lookup clipboard content |
+| **Productivity** | **Ctrl + Option + G** | Open Google Translate with clipboard content (EN→ZH-TW) |
+
+### Manual Setup (macOS)
+To manually install Karabiner and Hammerspoon configurations:
+
+```bash
+# Source the patch functions first
+source ~/.env/inc/patch.sh
+
+# Copy Karabiner config (backs up existing file automatically)
+patch_karabiner
+
+# Copy Hammerspoon config (backs up existing file automatically)
+patch_hammerspoon
+```
+
+Existing configurations are backed up with timestamps before being replaced (e.g., `init.lua.bak-2025-12-21-10-30-45`).
+
+**Note:** The functions must be sourced because `patch_karabiner` and `patch_hammerspoon` are bash functions defined in [inc/patch.sh](inc/patch.sh), not standalone executables.
 
 ## Customize & extend
 - Edit the seed files in `seeds/` to change defaults for shells, tmux, Vim/Neovim, Hammerspoon, or Karabiner.


### PR DESCRIPTION
Add a detailed macOS keyboard shortcuts table for Karabiner and Hammerspoon, along with instructions for manual setup. Update the README to note that existing config files are backed up with timestamped filenames (`.bak-YYYY-MM-DD-HH-MM-SS`) when copied, improving clarity around backup behavior.