### PR TITLE
feat(tmux): drag status-bar windows to reorder + patch existing configs

### DIFF
--- a/inc/patch.sh
+++ b/inc/patch.sh
@@ -87,18 +87,19 @@ function patch_shell_rc() {
     echo "$rc patched"
 }
 
-function patch_tmux_mouse() {
-    # Idempotently ensure the mouse settings exist in an already-patched
-    # ~/.tmux.conf (newer than the original seed block). Safe to re-run.
+function patch_tmux_settings() {
+    # Idempotently ensure newer tmux settings exist in an already-patched
+    # ~/.tmux.conf (added after the original seed block). Safe to re-run.
     local target_root="${TARGET_ROOT:-$HOME}"
     local tmuxrc=$target_root/.tmux.conf
     if [ ! -f "$tmuxrc" ]; then
         echo "$tmuxrc not found; run patch_tmux_rc first"
         return
     fi
-    echo "Ensuring tmux mouse settings in $tmuxrc ..."
+    echo "Ensuring tmux settings in $tmuxrc ..."
     ensure_line_in_file 'set -g mouse on' 'set -g mouse on' "$tmuxrc"
     ensure_line_in_file 'MouseDrag1Status' 'bind-key -n MouseDrag1Status swap-window -t=' "$tmuxrc"
+    ensure_line_in_file 'pane-border-lines' 'set -g pane-border-lines heavy' "$tmuxrc"
 }
 
 function patch_tmux_rc() {
@@ -109,7 +110,7 @@ function patch_tmux_rc() {
         cat "${ENV_ROOT}/seeds/tmux.conf" >> $tmuxrc
     else
         echo "$tmuxrc already patched"
-        patch_tmux_mouse
+        patch_tmux_settings
     fi
 
 }

--- a/inc/patch.sh
+++ b/inc/patch.sh
@@ -13,6 +13,20 @@ function get_line_number() {
     grep -n "$pattern" "$file" | cut -d: -f1
 }
 
+function ensure_line_in_file() {
+    if [ "$1" = "" ] || [ "$3" = "" ]; then
+        echo "Usage: ensure_line_in_file <match-pattern> <line> <file>"
+        return
+    fi
+    local pattern="$1"
+    local line="$2"
+    local file="$3"
+    if ! grep -qF "$pattern" "$file" 2> /dev/null; then
+        echo "$line" >> "$file"
+        echo "  + $line"
+    fi
+}
+
 function get_shell_rc_path() {
     local target_root="${TARGET_ROOT:-$HOME}"
     case "$1" in
@@ -73,6 +87,20 @@ function patch_shell_rc() {
     echo "$rc patched"
 }
 
+function patch_tmux_mouse() {
+    # Idempotently ensure the mouse settings exist in an already-patched
+    # ~/.tmux.conf (newer than the original seed block). Safe to re-run.
+    local target_root="${TARGET_ROOT:-$HOME}"
+    local tmuxrc=$target_root/.tmux.conf
+    if [ ! -f "$tmuxrc" ]; then
+        echo "$tmuxrc not found; run patch_tmux_rc first"
+        return
+    fi
+    echo "Ensuring tmux mouse settings in $tmuxrc ..."
+    ensure_line_in_file 'set -g mouse on' 'set -g mouse on' "$tmuxrc"
+    ensure_line_in_file 'MouseDrag1Status' 'bind-key -n MouseDrag1Status swap-window -t=' "$tmuxrc"
+}
+
 function patch_tmux_rc() {
     local target_root="${TARGET_ROOT:-$HOME}"
     local tmuxrc=$target_root/.tmux.conf
@@ -81,6 +109,7 @@ function patch_tmux_rc() {
         cat "${ENV_ROOT}/seeds/tmux.conf" >> $tmuxrc
     else
         echo "$tmuxrc already patched"
+        patch_tmux_mouse
     fi
 
 }

--- a/seeds/tmux.conf
+++ b/seeds/tmux.conf
@@ -24,6 +24,7 @@ set -g status-interval 1
 
 # show pane title
 set -g pane-border-status top
+set -g pane-border-lines heavy
 
 # tmux < 2.1
 # set -g mode-mouse on

--- a/seeds/tmux.conf
+++ b/seeds/tmux.conf
@@ -40,6 +40,10 @@ bind-key -T root PPage if-shell -F "#{alternate_on}" "send-keys PPage" "copy-mod
 bind-key -T root WheelUpPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; copy-mode -e; send-keys -M"
 bind-key -T root WheelDownPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; send-keys -M"
 
+# drag a window label in the status bar to reorder windows
+# (works on tmux <= 3.3; regressed on 3.4-3.5a, see tmux#4549)
+bind-key -n MouseDrag1Status swap-window -t=
+
 #bind-key -t vi-copy PPage page-up
 #bind-key -t vi-copy NPage page-down
 #bind-key -t vi-copy WheelUpPane halfpage-up


### PR DESCRIPTION
## What

- **`seeds/tmux.conf`** — bind `MouseDrag1Status` to `swap-window -t=`, so dragging a window label in the status bar reorders windows. (`set -g mouse on` was already present.)
- **`inc/patch.sh`** — new `ensure_line_in_file` helper and `patch_tmux_mouse` function. `patch_tmux_rc` now calls it in the *already-patched* branch, so existing `~/.tmux.conf` installs pick up the new mouse settings idempotently instead of being skipped.

## Why

`patch_tmux_rc` previously bailed out entirely when the `=Begin=` block already existed, so users who'd already run the patcher would never receive new tmux settings. `patch_tmux_mouse` appends only the missing lines.

## Version caveat

The `MouseDrag1Status` drag-to-reorder feature works on **tmux ≤ 3.3**; it's a known regression on **3.4–3.5a** with no fix released yet ([tmux#4549](https://github.com/tmux/tmux/issues/4549)). Noted in a comment beside the binding. The line is harmless on affected versions — it just won't drag.

## Testing

- `bash -n inc/patch.sh` passes.
- `patch_tmux_mouse` verified idempotent against a simulated already-patched `.tmux.conf`: first run appends the binding, second run adds nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)